### PR TITLE
fixed matching parentheses errors on 3 conditionals

### DIFF
--- a/plantFinder3000/plantScript.js
+++ b/plantFinder3000/plantScript.js
@@ -10,9 +10,9 @@ console.log(soilDrainage);
 
 $('.plantdiv').each(function(){
 if ( ($(this).hasClass(hardinessVal) &&
-($(this).hasClass(soilDrainage)|| soilDrainage === 'Uncertain/Raised'))) &&
+($(this).hasClass(soilDrainage)|| soilDrainage === 'Uncertain/Raised')) &&
 //added this in to try to make the loop cycle through the checkboxes as well
-($("#droughtTolerant").is(':checked'))
+($("#droughtTolerant").is(':checked')))
 {
   $(this).show();
 
@@ -20,16 +20,16 @@ if ( ($(this).hasClass(hardinessVal) &&
 //so if it doesnt return anything for 'droughtTolerant' it should run again and see if it finds a checked box for the other variables
 //if it doesn't find any checked boxes at all, it should just run a vanilla function without any checkbox search methods
 else if ( ($(this).hasClass(hardinessVal) &&
-($(this).hasClass(soilDrainage)|| soilDrainage === 'Uncertain/Raised')))&&
-($("#heatTolerant").is(':checked'))
+($(this).hasClass(soilDrainage)|| soilDrainage === 'Uncertain/Raised'))&&
+($("#heatTolerant").is(':checked')))
 {
   $(this).show();
 
 }
 
 else if ( ($(this).hasClass(hardinessVal) &&
-($(this).hasClass(soilDrainage)|| soilDrainage === 'Uncertain/Raised')))&&
-($("#coldTolerant").is(':checked'))
+($(this).hasClass(soilDrainage)|| soilDrainage === 'Uncertain/Raised'))&&
+($("#coldTolerant").is(':checked')))
 {
   $(this).show();
 


### PR DESCRIPTION
Same mis-matched parentheses error on each conditional. So I counted up open parens, closed parens and saw the mis-match.  Once I fixed one, applied same change to each conditional (as they in turn caused errors).

Take a look at the diff to see the removed lines (pink) and my correction (in green) to get an idea for what I did.
